### PR TITLE
Change attribute key type from &str to String

### DIFF
--- a/examples/ferris/block_rule.rs
+++ b/examples/ferris/block_rule.rs
@@ -14,10 +14,10 @@ impl NodeValue for BlockFerris {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
         // build attributes for `div`
         let mut attrs_div = node.attrs.clone();
-        attrs_div.push(("class", "ferris-block".into()));
+        attrs_div.push(("class".into(), "ferris-block".into()));
 
         // build attributes for `img`
-        let attrs_img = vec![("src", CRAB_URL.into())];
+        let attrs_img = vec![("src".into(), CRAB_URL.into())];
 
         fmt.cr(); // linebreak, multiples get merged
         fmt.open("div", &attrs_div); // opening tag, `<div>`

--- a/examples/ferris/core_rule.rs
+++ b/examples/ferris/core_rule.rs
@@ -18,7 +18,7 @@ impl NodeValue for FerrisCounter {
         let mut attrs = node.attrs.clone();
 
         // add a custom class attribute
-        attrs.push(("class", "ferris-counter".into()));
+        attrs.push(("class".into(), "ferris-counter".into()));
 
         fmt.cr(); // linebreak, multiples get merged
         fmt.open("footer", &attrs);

--- a/examples/ferris/inline_rule.rs
+++ b/examples/ferris/inline_rule.rs
@@ -17,7 +17,7 @@ impl NodeValue for InlineFerris {
         let mut attrs = node.attrs.clone();
 
         // add a custom class attribute
-        attrs.push(("class", "ferris-inline".into()));
+        attrs.push(("class".into(), "ferris-inline".into()));
 
         fmt.open("span", &attrs);
         fmt.text("🦀");

--- a/src/parser/node.rs
+++ b/src/parser/node.rs
@@ -24,7 +24,7 @@ pub struct Node {
     pub ext: NodeExtSet,
 
     /// Additional attributes to be added to resulting html.
-    pub attrs: Vec<(&'static str, String)>,
+    pub attrs: Vec<(String, String)>,
 
     /// Type name, used for debugging.
     #[readonly]

--- a/src/parser/renderer.rs
+++ b/src/parser/renderer.rs
@@ -11,11 +11,11 @@ use crate::Node;
 /// into internal buffer.
 pub trait Renderer {
     /// Write opening html tag with attributes, e.g. `<a href="url">`.
-    fn open(&mut self, tag: &str, attrs: &[(&str, String)]);
+    fn open(&mut self, tag: &str, attrs: &[(String, String)]);
     /// Write closing html tag, e.g. `</a>`.
     fn close(&mut self, tag: &str);
     /// Write self-closing html tag with attributes, e.g. `<img src="url"/>`.
-    fn self_close(&mut self, tag: &str, attrs: &[(&str, String)]);
+    fn self_close(&mut self, tag: &str, attrs: &[(String, String)]);
     /// Loop through child nodes and render each one.
     fn contents(&mut self, nodes: &[Node]);
     /// Write line break (`\n`). Default renderer ignores it if last char in the buffer is `\n` already.
@@ -56,14 +56,14 @@ impl<const XHTML: bool> HTMLRenderer<XHTML> {
         self.result.push('"');
     }
 
-    fn make_attrs(&mut self, attrs: &[(&str, String)]) {
+    fn make_attrs(&mut self, attrs: &[(String, String)]) {
         let mut attr_hash = HashMap::new();
         let mut attr_order = Vec::with_capacity(attrs.len());
 
         for (name, value) in attrs {
-            let entry = attr_hash.entry(*name).or_insert(Vec::new());
+            let entry = attr_hash.entry(name).or_insert(Vec::new());
             entry.push(value.as_str());
-            attr_order.push(*name);
+            attr_order.push(name);
         }
 
         for name in attr_order {
@@ -101,7 +101,7 @@ impl<const XHTML: bool> From<HTMLRenderer<XHTML>> for String {
 }
 
 impl<const XHTML: bool> Renderer for HTMLRenderer<XHTML> {
-    fn open(&mut self, tag: &str, attrs: &[(&str, String)]) {
+    fn open(&mut self, tag: &str, attrs: &[(String, String)]) {
         self.result.push('<');
         self.result.push_str(tag);
         self.make_attrs(attrs);
@@ -115,7 +115,7 @@ impl<const XHTML: bool> Renderer for HTMLRenderer<XHTML> {
         self.result.push('>');
     }
 
-    fn self_close(&mut self, tag: &str, attrs: &[(&str, String)]) {
+    fn self_close(&mut self, tag: &str, attrs: &[(String, String)]) {
         self.result.push('<');
         self.result.push_str(tag);
         self.make_attrs(attrs);

--- a/src/plugins/cmark/block/fence.rs
+++ b/src/plugins/cmark/block/fence.rs
@@ -27,7 +27,7 @@ impl NodeValue for CodeFence {
 
         if !lang_name.is_empty() {
             class = format!("{}{}", self.lang_prefix, lang_name);
-            attrs.push(("class", class));
+            attrs.push(("class".into(), class));
         }
 
         fmt.cr();

--- a/src/plugins/cmark/block/list.rs
+++ b/src/plugins/cmark/block/list.rs
@@ -24,7 +24,7 @@ impl NodeValue for OrderedList {
         let start;
         if self.start != 1 {
             start = self.start.to_string();
-            attrs.push(("start", start));
+            attrs.push(("start".into(), start));
         }
         fmt.cr();
         fmt.open("ol", &attrs);

--- a/src/plugins/cmark/inline/autolink.rs
+++ b/src/plugins/cmark/inline/autolink.rs
@@ -17,7 +17,7 @@ pub struct Autolink {
 impl NodeValue for Autolink {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
         let mut attrs = node.attrs.clone();
-        attrs.push(("href", self.url.clone()));
+        attrs.push(("href".into(), self.url.clone()));
 
         fmt.open("a", &attrs);
         fmt.contents(&node.children);

--- a/src/plugins/cmark/inline/image.rs
+++ b/src/plugins/cmark/inline/image.rs
@@ -15,11 +15,11 @@ pub struct Image {
 impl NodeValue for Image {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
         let mut attrs = node.attrs.clone();
-        attrs.push(("src", self.url.clone()));
-        attrs.push(("alt", node.collect_text()));
+        attrs.push(("src".into(), self.url.clone()));
+        attrs.push(("alt".into(), node.collect_text()));
 
         if let Some(title) = &self.title {
-            attrs.push(("title", title.clone()));
+            attrs.push(("title".into(), title.clone()));
         }
 
         fmt.self_close("img", &attrs);

--- a/src/plugins/cmark/inline/link.rs
+++ b/src/plugins/cmark/inline/link.rs
@@ -15,10 +15,10 @@ pub struct Link {
 impl NodeValue for Link {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
         let mut attrs = node.attrs.clone();
-        attrs.push(("href", self.url.clone()));
+        attrs.push(("href".into(), self.url.clone()));
 
         if let Some(title) = &self.title {
-            attrs.push(("title", title.clone()));
+            attrs.push(("title".into(), title.clone()));
         }
 
         fmt.open("a", &attrs);

--- a/src/plugins/extra/heading_anchors.rs
+++ b/src/plugins/extra/heading_anchors.rs
@@ -62,7 +62,7 @@ impl CoreRule for AddHeadingAnchors {
 
         root.walk_mut(|node, _| {
             if node.is::<ATXHeading>() || node.is::<SetextHeader>() {
-                node.attrs.push(("id", slugify(&node.collect_text())));
+                node.attrs.push(("id".into(), slugify(&node.collect_text())));
             }
         });
     }

--- a/src/plugins/extra/linkify.rs
+++ b/src/plugins/extra/linkify.rs
@@ -23,7 +23,7 @@ pub struct Linkified {
 impl NodeValue for Linkified {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
         let mut attrs = node.attrs.clone();
-        attrs.push(("href", self.url.clone()));
+        attrs.push(("href".into(), self.url.clone()));
 
         fmt.open("a", &attrs);
         fmt.contents(&node.children);

--- a/src/plugins/extra/tables.rs
+++ b/src/plugins/extra/tables.rs
@@ -106,9 +106,9 @@ impl NodeValue for TableCell {
 
         match ctx.alignments.get(ctx.index).copied().unwrap_or_default() {
             ColumnAlignment::None => (),
-            ColumnAlignment::Left => attrs.push(("style", "text-align:left".to_owned())),
-            ColumnAlignment::Right => attrs.push(("style", "text-align:right".to_owned())),
-            ColumnAlignment::Center => attrs.push(("style", "text-align:center".to_owned())),
+            ColumnAlignment::Left => attrs.push(("style".into(), "text-align:left".to_owned())),
+            ColumnAlignment::Right => attrs.push(("style".into(), "text-align:right".to_owned())),
+            ColumnAlignment::Center => attrs.push(("style".into(), "text-align:center".to_owned())),
         }
 
         ctx.index += 1;

--- a/src/plugins/sourcepos.rs
+++ b/src/plugins/sourcepos.rs
@@ -29,7 +29,7 @@ impl CoreRule for SyntaxPosRule {
         root.walk_mut(|node, _| {
             if let Some(map) = node.srcmap {
                 let ((startline, startcol), (endline, endcol)) = map.get_positions(&mapping);
-                node.attrs.push(("data-sourcepos", format!("{}:{}-{}:{}", startline, startcol, endline, endcol)));
+                node.attrs.push(("data-sourcepos".into(), format!("{}:{}-{}:{}", startline, startcol, endline, endcol)));
             }
         });
     }


### PR DESCRIPTION
Allows to store attribute keys as String instead of &'static str.